### PR TITLE
Fix env_logger warning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ async fn main() -> std::io::Result<()> {
     let piping_server = &PipingServer::new();
 
     // Set default log level
-    env_logger::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     let https_server = if opt.enable_https {
         if let (Some(https_port), Some(crt_path), Some(key_path)) =


### PR DESCRIPTION
This fixes following build warning:

```
warning: use of deprecated function `env_logger::from_env`: Prefer `env_logger::Builder::from_env()` instead.
  --> src/main.rs:46:5
   |
46 |     env_logger::from_env(env_logger::Env::default().default_filter_or("info")).init();
   |     ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```