### PR TITLE
Update to Rust 1.56.0 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "piping-server"
 version = "0.9.1"
 authors = ["Ryo Ota <nwtgck@nwtgck.org>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 hyper = { version = "0.14", features = ["stream", "server", "http1", "http2", "tcp"] }


### PR DESCRIPTION
Hi developer of a great library!
I have updated to [Rust 1.56.0 2021 edition](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html).

### Update Flow

```bash
rustup update stable
cargo fix --edition
sed -i "s/2018/2021/" Cargo.toml
cargo build --release
```

### Tested build targets

- [x] x86_64-unknown-linux-gnu
- [x] x86_64-pc-windows-gnu
- [x] x86-64-apple-darwin