### PR TITLE
fix: halfway disconnect message when sender does not use chunked transfer encoding

### DIFF
--- a/src/piping_server.rs
+++ b/src/piping_server.rs
@@ -520,7 +520,7 @@ async fn transfer(
         get_transfer_request(&data_sender_req_headers, data_sender_req_body).await?;
     // The finish_waiter will tell when the body is finished
     let (finish_detectable_body, sender_req_body_finish_waiter) =
-        finish_detectable_body(transfer_request.body);
+        finish_detectable_body(transfer_request.body, Some(&data_sender_req_headers));
     let x_piping = data_sender_req_headers.get_all("x-piping");
     let has_x_piping = data_sender_req_headers.contains_key("x-piping");
     // Create receiver's response

--- a/src/piping_server.rs
+++ b/src/piping_server.rs
@@ -520,7 +520,7 @@ async fn transfer(
         get_transfer_request(&data_sender_req_headers, data_sender_req_body).await?;
     // The finish_waiter will tell when the body is finished
     let (finish_detectable_body, sender_req_body_finish_waiter) =
-        finish_detectable_body(transfer_request.body, Some(&data_sender_req_headers));
+        finish_detectable_body(transfer_request.body);
     let x_piping = data_sender_req_headers.get_all("x-piping");
     let has_x_piping = data_sender_req_headers.contains_key("x-piping");
     // Create receiver's response

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,15 +62,29 @@ impl HeaderValuesBuilder for http::response::Builder {
     }
 }
 
+#[derive(Debug)]
+enum TransferMode {
+    ContentLength {
+        expected: u64,
+        received: u64,
+    },
+    Chunked,
+}
+
 pin_project! {
     pub struct FinishDetectableBody<B> {
         #[pin]
         body: B,
         finish_notifier: Option<futures::channel::oneshot::Sender<()>>,
+        transfer_mode: TransferMode,
     }
 }
 
-impl<B: http_body::Body> http_body::Body for FinishDetectableBody<B> {
+impl<B> http_body::Body for FinishDetectableBody<B> 
+where 
+    B: http_body::Body,
+    B::Data: AsRef<[u8]>,  // Add this constraint
+{
     type Data = B::Data;
     type Error = B::Error;
 
@@ -80,15 +94,35 @@ impl<B: http_body::Body> http_body::Body for FinishDetectableBody<B> {
     ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
         let mut this = self.project();
         match this.body.as_mut().poll_frame(cx) {
-            // If body is finished
+            // Determine if body is finished by counting the bytes and comparing to Content-Length
+            Poll::Ready(Some(Ok(frame))) => {
+                // Only count bytes if we're in ContentLength mode
+                if let TransferMode::ContentLength { received, expected } = this.transfer_mode {
+                    if let Some(data) = frame.data_ref() {
+                        let new_received = *received + data.as_ref().len() as u64;
+                        if new_received >= *expected {
+                            if let Some(notifier) = this.finish_notifier.take() {
+                                notifier.send(()).unwrap();
+                            }
+                        }
+                        // Update the received count
+                        if let TransferMode::ContentLength { ref mut received, .. } = this.transfer_mode {
+                            *received = new_received;
+                        }
+                    }
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            // If body is finished (chunked transfer end or connection closed)
             Poll::Ready(None) => {
-                // Notify finish
+                // For both modes, end of stream means we're done
                 if let Some(notifier) = this.finish_notifier.take() {
                     notifier.send(()).unwrap();
                 }
                 Poll::Ready(None)
             }
-            poll => poll,
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
         }
     }
 
@@ -105,15 +139,30 @@ impl<B: http_body::Body> http_body::Body for FinishDetectableBody<B> {
 
 pub fn finish_detectable_body<B: http_body::Body>(
     body: B,
+    headers: Option<&http::HeaderMap>,
 ) -> (
     FinishDetectableBody<B>,
     futures::channel::oneshot::Receiver<()>,
 ) {
     let (finish_notifier, finish_waiter) = futures::channel::oneshot::channel::<()>();
+    
+    // Determine transfer mode from headers
+    let transfer_mode = match headers.and_then(|h| h.get(http::header::CONTENT_LENGTH)) {
+        Some(content_length) => match content_length.to_str().ok().and_then(|s| s.parse::<u64>().ok()) {
+            Some(expected) => TransferMode::ContentLength {
+                expected,
+                received: 0
+            },
+            None => TransferMode::Chunked
+        },
+        None => TransferMode::Chunked
+    };
+
     (
         FinishDetectableBody {
             body,
             finish_notifier: Some(finish_notifier),
+            transfer_mode,
         },
         finish_waiter,
     )

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,29 +62,15 @@ impl HeaderValuesBuilder for http::response::Builder {
     }
 }
 
-#[derive(Debug)]
-enum TransferMode {
-    ContentLength {
-        expected: u64,
-        received: u64,
-    },
-    Chunked,
-}
-
 pin_project! {
     pub struct FinishDetectableBody<B> {
         #[pin]
         body: B,
         finish_notifier: Option<futures::channel::oneshot::Sender<()>>,
-        transfer_mode: TransferMode,
     }
 }
 
-impl<B> http_body::Body for FinishDetectableBody<B> 
-where 
-    B: http_body::Body,
-    B::Data: AsRef<[u8]>,  // Add this constraint
-{
+impl<B: http_body::Body> http_body::Body for FinishDetectableBody<B> {
     type Data = B::Data;
     type Error = B::Error;
 
@@ -94,35 +80,26 @@ where
     ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
         let mut this = self.project();
         match this.body.as_mut().poll_frame(cx) {
-            // Determine if body is finished by counting the bytes and comparing to Content-Length
-            Poll::Ready(Some(Ok(frame))) => {
-                // Only count bytes if we're in ContentLength mode
-                if let TransferMode::ContentLength { received, expected } = this.transfer_mode {
-                    if let Some(data) = frame.data_ref() {
-                        let new_received = *received + data.as_ref().len() as u64;
-                        if new_received >= *expected {
-                            if let Some(notifier) = this.finish_notifier.take() {
-                                notifier.send(()).unwrap();
-                            }
-                        }
-                        // Update the received count
-                        if let TransferMode::ContentLength { ref mut received, .. } = this.transfer_mode {
-                            *received = new_received;
-                        }
+            poll @ Poll::Ready(Some(_)) => {
+                // Workaround: fixed-length body can not be Poll::Ready(None)
+                // https://github.com/nwtgck/piping-server-rust/pull/718
+                if this.body.is_end_stream() {
+                    // Notify finish
+                    if let Some(notifier) = this.finish_notifier.take() {
+                        notifier.send(()).unwrap();
                     }
                 }
-                Poll::Ready(Some(Ok(frame)))
+                poll
             }
-            // If body is finished (chunked transfer end or connection closed)
+            // If body is finished
             Poll::Ready(None) => {
-                // For both modes, end of stream means we're done
+                // Notify finish
                 if let Some(notifier) = this.finish_notifier.take() {
                     notifier.send(()).unwrap();
                 }
                 Poll::Ready(None)
             }
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            poll => poll,
         }
     }
 
@@ -139,30 +116,15 @@ where
 
 pub fn finish_detectable_body<B: http_body::Body>(
     body: B,
-    headers: Option<&http::HeaderMap>,
 ) -> (
     FinishDetectableBody<B>,
     futures::channel::oneshot::Receiver<()>,
 ) {
     let (finish_notifier, finish_waiter) = futures::channel::oneshot::channel::<()>();
-    
-    // Determine transfer mode from headers
-    let transfer_mode = match headers.and_then(|h| h.get(http::header::CONTENT_LENGTH)) {
-        Some(content_length) => match content_length.to_str().ok().and_then(|s| s.parse::<u64>().ok()) {
-            Some(expected) => TransferMode::ContentLength {
-                expected,
-                received: 0
-            },
-            None => TransferMode::Chunked
-        },
-        None => TransferMode::Chunked
-    };
-
     (
         FinishDetectableBody {
             body,
             finish_notifier: Some(finish_notifier),
-            transfer_mode,
         },
         finish_waiter,
     )


### PR DESCRIPTION
See https://github.com/nwtgck/piping-server-rust/issues/716

I'm mainly a C++ and Python developer, so my Rust code may not be up to the standards! Please review carefully.